### PR TITLE
(docs): Add a section to the readme for the Cloudflare KV adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,61 @@ const data = await cachified({
 });
 ```
 
+### Adapter for [Cloudflare KV](https://developers.cloudflare.com/kv/)
+
+For additional information or to report issues, please visit the [cachified-adapter-cloudflare-kv repository](https://github.com/AdiRishi/cachified-adapter-cloudflare-kv).
+
+```ts
+import { cachified, Cache } from '@epic-web/cachified';
+import { cloudflareKvCacheAdapter } from 'cachified-adapter-cloudflare-kv';
+
+export interface Env {
+  KV: KVNamespace;
+  CACHIFIED_KV_CACHE: Cache;
+}
+
+export async function getUserById(
+  userId: number,
+  env: Env,
+): Promise<Record<string, unknown>> {
+  return cachified({
+    key: `user-${userId}`,
+    cache: env.CACHIFIED_KV_CACHE,
+    async getFreshValue() {
+      const response = await fetch(
+        `https://jsonplaceholder.typicode.com/users/${userId}`,
+      );
+      return response.json();
+    },
+    ttl: 60_000, // 1 minute
+    staleWhileRevalidate: 300_000, // 5 minutes
+  });
+}
+
+export default {
+  async fetch(
+    request: Request,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<Response> {
+    // It is a common pattern to pass around the env object to most functions when writing workers code
+    // So it's convenient to inject the cache adapter into the env object
+    env.CACHIFIED_KV_CACHE = cloudflareKvCacheAdapter({
+      kv: env.KV,
+      keyPrefix: 'mycache', // optional
+      name: 'CloudflareKV', // optional
+    });
+    const userId = Math.floor(Math.random() * 10) + 1;
+    const user = await getUserById(userId, env);
+    return new Response(JSON.stringify(user), {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  },
+};
+```
+
 ## Advanced Usage
 
 ### Stale while revalidate

--- a/README.md
+++ b/README.md
@@ -329,8 +329,6 @@ export default {
     env: Env,
     ctx: ExecutionContext,
   ): Promise<Response> {
-    // It is a common pattern to pass around the env object to most functions when writing workers code
-    // So it's convenient to inject the cache adapter into the env object
     env.CACHIFIED_KV_CACHE = cloudflareKvCacheAdapter({
       kv: env.KV,
       keyPrefix: 'mycache', // optional


### PR DESCRIPTION
Resolves #71 

As requested by @kentcdodds the adapter originally made in https://github.com/epicweb-dev/cachified/pull/72 has been moved to it's own package and repository.

Github - https://github.com/AdiRishi/cachified-adapter-cloudflare-kv
Npm - https://www.npmjs.com/package/cachified-adapter-cloudflare-kv

This PR adds a section to the readme giving a brief starter guide along with a link to the adapter github repository.