### PR TITLE
Prefer type inference from options#getFreshValue over reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,13 +213,6 @@ interface CachifiedOptions<Value> {
    * Default: `0`
    */
   staleRefreshTimeout?: number;
-  /**
-   * A reporter receives events during the runtime of
-   * cachified and can be used for debugging and monitoring
-   *
-   * Default: `undefined` - no reporting
-   */
-  reporter?: CreateReporter<Value>;
 }
 ```
 
@@ -790,7 +783,7 @@ console.log(await getUsersWithId([2, 3]));
 
 ### Reporting
 
-A reporter might be passed to cachified to log caching events, we ship a reporter
+A reporter might be passed as second argument to cachified to log caching events, we ship a reporter
 resembling the logging from [Kents implementation](https://github.com/kentcdodds/kentcdodds.com/blob/3efd0d3a07974ece0ee64d665f5e2159a97585df/app/utils/cache.server.ts)
 
 <!-- verbose-reporter -->
@@ -800,18 +793,19 @@ import { cachified, verboseReporter } from '@epic-web/cachified';
 
 const cache = new Map();
 
-await cachified({
-  reporter: verboseReporter(),
-
-  cache,
-  key: 'user-1',
-  async getFreshValue() {
-    const response = await fetch(
-      `https://jsonplaceholder.typicode.com/users/1`,
-    );
-    return response.json();
+await cachified(
+  {
+    cache,
+    key: 'user-1',
+    async getFreshValue() {
+      const response = await fetch(
+        `https://jsonplaceholder.typicode.com/users/1`,
+      );
+      return response.json();
+    },
   },
-});
+  verboseReporter(),
+);
 ```
 
 please refer to [the implementation of `verboseReporter`](https://github.com/epicweb-dev/cachified/blob/main/src/reporter.ts#L125) when you want to implement a custom reporter.

--- a/src/cachified.ts
+++ b/src/cachified.ts
@@ -7,6 +7,7 @@ import {
 } from './common';
 import { CACHE_EMPTY, getCachedValue } from './getCachedValue';
 import { getFreshValue } from './getFreshValue';
+import { CreateReporter } from './reporter';
 import { shouldRefresh } from './shouldRefresh';
 
 // This is to prevent requesting multiple fresh values in parallel
@@ -16,14 +17,17 @@ const pendingValuesByCache = new WeakMap<Cache, Map<string, any>>();
 
 export async function cachified<Value, InternalValue>(
   options: CachifiedOptionsWithSchema<Value, InternalValue>,
+  reporter?: CreateReporter<Value>,
 ): Promise<Value>;
 export async function cachified<Value>(
   options: CachifiedOptions<Value>,
+  reporter?: CreateReporter<Value>,
 ): Promise<Value>;
 export async function cachified<Value>(
   options: CachifiedOptions<Value>,
+  reporter?: CreateReporter<Value>,
 ): Promise<Value> {
-  const context = createContext(options);
+  const context = createContext(options, reporter);
   const { key, cache, forceFresh, report, metadata } = context;
 
   // Register this cache

--- a/src/common.ts
+++ b/src/common.ts
@@ -175,12 +175,9 @@ export interface CachifiedOptions<Value> {
    */
   staleRefreshTimeout?: number;
   /**
-   * A reporter receives events during the runtime of
-   * cachified and can be used for debugging and monitoring
-   *
-   * Default: `undefined` - no reporting
+   * @deprecated pass reporter as second argument to cachified
    */
-  reporter?: CreateReporter<Value> | null;
+  reporter?: never;
 }
 
 /* When using a schema validator, a strongly typed getFreshValue is not required
@@ -204,12 +201,10 @@ export interface Context<Value>
   metadata: CacheMetadata;
 }
 
-export function createContext<Value>({
-  fallbackToCache,
-  reporter,
-  checkValue,
-  ...options
-}: CachifiedOptions<Value>): Context<Value> {
+export function createContext<Value>(
+  { fallbackToCache, checkValue, ...options }: CachifiedOptions<Value>,
+  reporter?: CreateReporter<Value>,
+): Context<Value> {
   const ttl = options.ttl ?? Infinity;
   const staleWhileRevalidate = options.swr ?? options.staleWhileRevalidate ?? 0;
   const checkValueCompat: CheckValue<Value> =

--- a/src/getCachedValue.ts
+++ b/src/getCachedValue.ts
@@ -57,7 +57,6 @@ export async function getCachedValue<Value>(
         report({ name: 'refreshValueStart' });
         void cachified({
           ...context,
-          reporter: () => () => {},
           getFreshValue({ metadata }) {
             return context.getFreshValue({ metadata, background: true });
           },

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -137,6 +137,7 @@ function formatCacheTime(
   return `${formatDuration(metadata.ttl)} + ${formatDuration(swr)} stale`;
 }
 
+export type NoInfer<T> = [T][T extends any ? 0 : never];
 interface ReporterOpts {
   formatDuration?: (ms: number) => string;
   logger?: Pick<typeof console, 'log' | 'warn' | 'error'>;


### PR DESCRIPTION
This fixes an issue where the `unknown` Value type of some reporters has been infered by cachified thereby ignoring the much more useful return type of `getFreshValue`

fix https://github.com/epicweb-dev/cachified/issues/70

BREAKING CHANGE:
`CachifiedOptions#reporter` has been removed in favor of passing a reporter as second argument to cachified

MIGRATION:
Change `cachified({ reporter: myReporter /* ... */ })` to `cachified({ /* ... */ }, myReporter)`