### PR TITLE
Pass background tasks as Promise to new waitUntil option

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,15 @@ interface CachifiedOptions<Value> {
    * Default: `0`
    */
   staleRefreshTimeout?: number;
+  /**
+   * Promises passed to `waitUntil` represent background tasks which must be
+   * completed before the server can shutdown. e.g. swr cache revalidation
+   *
+   * Useful for serverless environments such as Cloudflare Workers.
+   *
+   * Default: `undefined`
+   */
+  waitUntil?: (promise: Promise<unknown>) => void;
 }
 ```
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -178,6 +178,15 @@ export interface CachifiedOptions<Value> {
    * @deprecated pass reporter as second argument to cachified
    */
   reporter?: never;
+  /**
+   * Promises passed to `waitUntil` represent background tasks which must be
+   * completed before the server can shutdown. e.g. swr cache revalidation
+   *
+   * Useful for serverless environments such as Cloudflare Workers.
+   *
+   * Default: `undefined`
+   */
+  waitUntil?: (promise: Promise<unknown>) => void;
 }
 
 /* When using a schema validator, a strongly typed getFreshValue is not required
@@ -229,6 +238,7 @@ export function createContext<Value>(
     forceFresh: false,
     ...options,
     metadata: createCacheMetaData({ ttl, swr: staleWhileRevalidate }),
+    waitUntil: options.waitUntil ?? (() => {}),
   };
 
   const report =


### PR DESCRIPTION
When running in a serverless environment such as Cloudflare Workers any background tasks such as cache revalidation and value migration aren't guaranteed to complete successfully because the serverless process is likely to be killed once it's handled the request.

This PR adds a new `waitUntil` option which allows call sites to pass in a callback accepting a promise representing background tasks.

In practice on CF Workers this would look like this:
```ts
export default {
  async fetch(request, env, ctx) {
    const result = await cachified({
      key: 'test',
      cache: lru,
      async getFreshValue() {
        const response = await fetch(
          `https://jsonplaceholder.typicode.com/users`,
        );
        return response.json();
      },
      ttl: 300_000,
      waitUntil: ctx.waitUntil.bind(ctx).
    });

    return new Response(result);
  },
};
```

https://developers.cloudflare.com/workers/runtime-apis/context/#waituntil

https://github.com/epicweb-dev/cachified/issues/71#issuecomment-2100172163