### PR TITLE
chore(README): add `cachified-adapter-sqlite`

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ There are some adapters available for common caches. Using them makes sure the u
 - Adapter for [redis](https://www.npmjs.com/package/redis) : [cachified-redis-adapter](https://www.npmjs.com/package/cachified-redis-adapter)
 - Adapter for [redis-json](https://www.npmjs.com/package/@redis/json) : [cachified-redis-json-adapter](https://www.npmjs.com/package/cachified-redis-json-adapter)
 - Adapter for [Cloudflare KV](https://developers.cloudflare.com/kv/) : [cachified-adapter-cloudflare-kv repository](https://github.com/AdiRishi/cachified-adapter-cloudflare-kv)
+- Adapter for SQLite : [cachified-adapter-sqlite](https://npmjs.com/package/cachified-adapter-sqlite)
 
 ## Advanced Usage
 


### PR DESCRIPTION
Hi!

Thank you for this amazing library.

I've published my SQLite cache adapter that I've been using internally for a while on NPM now: [`cachified-adapter-sqlite`](https://www.npmjs.com/package/cachified-adapter-sqlite)

The adapter supports all major SQLite drivers, including [`better-sqlite3`](https://github.com/WiseLibs/better-sqlite3), [`sqlite`](https://github.com/kriasoft/node-sqlite), [`sqlite3`](https://github.com/TryGhost/node-sqlite3), and [`bun:sqlite`](https://bun.sh/docs/api/sqlite).

This PR adds a link to this package to the README.

Happy to hear your feedback!