### PR TITLE
Add configure helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,28 @@ console.log(await getUserById(1));
 // Cache was filled an valid. `getFreshValue` was not invoked
 ```
 
+### Pre-configuring cachified
+
+We can create versions of cachified with defaults so that we don't have to
+specify the same options every time.
+
+<!-- pre-configured-cachified -->
+
+```ts
+import { configure } from '@epic-web/cachified';
+import { LRUCache } from 'lru-cache';
+
+/* lruCachified now has a default cache */
+const lruCachified = configure({
+  cache: new LRUCache<string, CacheEntry>({ max: 1000 }),
+});
+
+const value = await lruCachified({
+  key: 'user-1',
+  getFreshValue: async () => 'ONE',
+});
+```
+
 ### Manually working with the cache
 
 During normal app lifecycle there usually is no need for this but for

--- a/src/cachified.spec.ts
+++ b/src/cachified.spec.ts
@@ -12,6 +12,7 @@ import {
 } from './index';
 import { Deferred } from './createBatch';
 import { delay, report } from './testHelpers';
+import { configure } from './configure';
 
 jest.mock('./index', () => {
   if (process.version.startsWith('v20')) {
@@ -1535,6 +1536,22 @@ describe('cachified', () => {
       metadata: { ttl: null, swr: null, createdTime: Date.now() },
     });
     expect(await getValue(() => () => {})).toBe('FOUR');
+  });
+
+  it('supports creating pre-configured cachified functions', async () => {
+    const configuredCachified = configure({
+      cache: new Map(),
+    });
+
+    const value = await configuredCachified({
+      key: 'test',
+      // look mom, no cache!
+      getFreshValue() {
+        return 'ONE';
+      },
+    });
+
+    expect(value).toBe('ONE');
   });
 });
 

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -1,0 +1,43 @@
+import { cachified } from './cachified';
+import { CachifiedOptions, CachifiedOptionsWithSchema } from './common';
+import { CreateReporter, mergeReporters } from './reporter';
+
+type PartialOptions<
+  Options extends CachifiedOptions<any>,
+  OptionalKeys extends string | number | symbol,
+> = Omit<Options, OptionalKeys> &
+  Partial<Pick<Options, Extract<OptionalKeys, keyof Options>>>;
+
+/**
+ * create a pre-configured version of cachified
+ */
+export function configure<
+  ConfigureValue extends unknown,
+  Opts extends Partial<CachifiedOptions<ConfigureValue>>,
+>(defaultOptions: Opts, defaultReporter?: CreateReporter<ConfigureValue>) {
+  function configuredCachified<Value, InternalValue>(
+    options: PartialOptions<
+      CachifiedOptionsWithSchema<Value, InternalValue>,
+      keyof Opts
+    >,
+    reporter?: CreateReporter<Value>,
+  ): Promise<Value>;
+  async function configuredCachified<Value>(
+    options: PartialOptions<CachifiedOptions<Value>, keyof Opts>,
+    reporter?: CreateReporter<Value>,
+  ): Promise<Value>;
+  function configuredCachified<Value>(
+    options: PartialOptions<CachifiedOptions<Value>, keyof Opts>,
+    reporter?: CreateReporter<Value>,
+  ) {
+    return cachified(
+      {
+        ...defaultOptions,
+        ...options,
+      } as any as CachifiedOptions<Value>,
+      mergeReporters(defaultReporter as any as CreateReporter<Value>, reporter),
+    );
+  }
+
+  return configuredCachified;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,4 @@ export { cachified as default } from './cachified';
 export { shouldRefresh } from './shouldRefresh';
 export { assertCacheEntry } from './assertCacheEntry';
 export { softPurge } from './softPurge';
+export { configure } from './configure';


### PR DESCRIPTION
I find myself often wanting to pre-configure cachified with default caches and reporters.
But updating the typescript interface isn't trivial. 
The `configure` helper solves this.

```ts
import { configure } from '@epic-web/cachified';
import { LRUCache } from 'lru-cache';

/* lruCachified now has a default cache */
const lruCachified = configure({
  cache: new LRUCache<string, CacheEntry>({ max: 1000 }),
});

const value = await lruCachified({
  // no need for `cache`
  key: 'user-1',
  getFreshValue: async () => 'ONE',
});
```