### PR TITLE
Fix delayed background de-duplication and deprecate `deprecate-staleRefreshTimeout` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,15 +225,6 @@ interface CachifiedOptions<Value> {
    */
   fallbackToCache?: boolean | number;
   /**
-   * Amount of time in milliseconds before revalidation of a stale
-   * cache entry is started
-   *
-   * Must be positive and finite
-   *
-   * Default: `0`
-   */
-  staleRefreshTimeout?: number;
-  /**
    * Promises passed to `waitUntil` represent background tasks which must be
    * completed before the server can shutdown. e.g. swr cache revalidation
    *

--- a/src/common.ts
+++ b/src/common.ts
@@ -184,6 +184,8 @@ export interface CachifiedOptions<Value> {
    * Must be positive and finite
    *
    * Default: `0`
+   * @deprecated manually delay background refreshes in getFreshValue instead
+   * @see https://github.com/epicweb-dev/cachified/issues/132
    */
   staleRefreshTimeout?: number;
   /**

--- a/src/getCachedValue.ts
+++ b/src/getCachedValue.ts
@@ -58,6 +58,12 @@ export async function getCachedValue<Value>(
           await cachified({
             ...context,
             async getFreshValue({ metadata }) {
+              /* TODO: When staleRefreshTimeout option is removed we should
+               also remove this or set it to ~0-200ms depending on ttl values.
+               The intention of the delay is to not take sync resources for
+               background refreshing – still we need to queue the refresh
+               directly so that the de-duplication works.
+               See https://github.com/epicweb-dev/cachified/issues/132 */
               await sleep(staleRefreshTimeout);
               report({ name: 'refreshValueStart' });
               return context.getFreshValue({ metadata, background: true });

--- a/src/getCachedValue.ts
+++ b/src/getCachedValue.ts
@@ -55,11 +55,11 @@ export async function getCachedValue<Value>(
       // refresh cache in background so future requests are faster
       context.waitUntil(
         Promise.resolve().then(async () => {
-          await sleep(staleRefreshTimeout);
-          report({ name: 'refreshValueStart' });
           await cachified({
             ...context,
-            getFreshValue({ metadata }) {
+            async getFreshValue({ metadata }) {
+              await sleep(staleRefreshTimeout);
+              report({ name: 'refreshValueStart' });
               return context.getFreshValue({ metadata, background: true });
             },
             forceFresh: true,

--- a/src/getCachedValue.ts
+++ b/src/getCachedValue.ts
@@ -54,30 +54,28 @@ export async function getCachedValue<Value>(
     if (staleRefresh) {
       // refresh cache in background so future requests are faster
       context.waitUntil(
-        Promise.resolve().then(async () => {
-          await cachified({
-            ...context,
-            async getFreshValue({ metadata }) {
-              /* TODO: When staleRefreshTimeout option is removed we should
+        cachified({
+          ...context,
+          async getFreshValue({ metadata }) {
+            /* TODO: When staleRefreshTimeout option is removed we should
                also remove this or set it to ~0-200ms depending on ttl values.
                The intention of the delay is to not take sync resources for
                background refreshing – still we need to queue the refresh
                directly so that the de-duplication works.
                See https://github.com/epicweb-dev/cachified/issues/132 */
-              await sleep(staleRefreshTimeout);
-              report({ name: 'refreshValueStart' });
-              return context.getFreshValue({ metadata, background: true });
-            },
-            forceFresh: true,
-            fallbackToCache: false,
+            await sleep(staleRefreshTimeout);
+            report({ name: 'refreshValueStart' });
+            return context.getFreshValue({ metadata, background: true });
+          },
+          forceFresh: true,
+          fallbackToCache: false,
+        })
+          .then((value) => {
+            report({ name: 'refreshValueSuccess', value });
           })
-            .then((value) => {
-              report({ name: 'refreshValueSuccess', value });
-            })
-            .catch((error) => {
-              report({ name: 'refreshValueError', error });
-            });
-        }),
+          .catch((error) => {
+            report({ name: 'refreshValueError', error });
+          }),
       );
     }
 


### PR DESCRIPTION
1. **Background refreshes are now de-duplicated as expected**
   By moving the timeout/sleep just before the potential heavy work happens in `getFreshValue` 
2. `deprecate-staleRefreshTimeout` is deprecated as an option in favor of manually handling it like 
    
    As discussed in https://github.com/epicweb-dev/cachified/issues/132, this option was only added to stay 100% backwards compatible with the original implementation and now seems to be rather misleading.