### PR TITLE
Export `CachifiedOptionsWithSchema` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export type {
   CachifiedOptions,
+  CachifiedOptionsWithSchema,
   Cache,
   CacheEntry,
   CacheMetadata,


### PR DESCRIPTION
to fix:
> The inferred type of 'cache' cannot be named without a reference to '../../../../node_modules/@epic-web/cachified/dist/src/common'. This is likely not portable. A type annotation is necessary.ts(2742)

When using `configure`